### PR TITLE
Removed RemovedInDjango110Warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ django_root/static
 *.egg-info
 *.swo
 dist/
+
+
+*sublime*

--- a/makeconf/management/commands/makeconf.py
+++ b/makeconf/management/commands/makeconf.py
@@ -5,7 +5,7 @@ import shutil
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.template import loader, Context
+from django.template import loader
 
 
 class InvalidVarException(object):
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         self.executable_extensions = settings.MAKECONF_OPTIONS.get(
             'executable_extensions', ['.sh'])
 
-        context = Context({'settings': settings})
+        context = {'settings': settings}
         self.stdout.write('context is: {}'.format(context))
 
         for path, template in sorted(self._get_template_map().items()):


### PR DESCRIPTION
Do with what you will, but I'm on Django 1.9 and there's a warning pre-Django 1.10 where render is not to be called with a `Context` any longer: 

> makeconf.py:31: RemovedInDjango110Warning: render() must be called with a dict, not a Context.
>   output = template.render(context)

...so I've made a slight change to remove that warning and I've tested with zero issues.  
